### PR TITLE
Creating Makefile with basic targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea/
+coverage.out
 go.sum
 
 #binary files

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build clean run test
+
+build:
+	GOCGO=CGO_ENABLED=1 go build -o go-simulator
+
+clean:
+	rm ./go-simulator
+
+run:
+	cd bin && ./launch.sh
+
+test:
+	go test -coverprofile=coverage.out ./...
+	go vet ./...
+	gofmt -l .
+	[ "`gofmt -l .`" = "" ]

--- a/bin/launch.sh
+++ b/bin/launch.sh
@@ -1,0 +1,11 @@
+# Kill all lingering related processes
+function cleanup {
+	pkill go-simulator
+}
+
+cd ..
+exec -a go-simulator ./go-simulator &
+
+trap cleanup EXIT
+
+while : ; do sleep 1 ; done

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func simulateSensor(frequency int64) {
 }
 
 func main() {
-
+	fmt.Println("Starting go-simulator...")
 	httpRouter := api.NewRouter()
 	configuration.InitConfig()
 	srv := &http.Server{


### PR DESCRIPTION
Fix #2

Using the included Makefile will provide easy command line capability
to build, test and run the go-simulator application.

'make build' builds the application
'make clean' cleans the built executable from the directory
'make run' runs the executable
'make test' will run any unit tests in the project and capture coverage
            statistics in a coverage.out file

Also added a line of output at the beginning of main() to confirm the
application is starting upon invocation.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>