### PR TITLE
Revising Makefile build target (Remove GOCGO)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build clean run test
 
 build:
-	GOCGO=CGO_ENABLED=1 go build -o go-simulator
+	CGO_ENABLED=1 go build -o go-simulator
 
 clean:
 	rm ./go-simulator


### PR DESCRIPTION
Fix #5 

One line change to remove erroneous setting of GOCGO in make build
target.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>